### PR TITLE
Fix for issue #57

### DIFF
--- a/source/private/New-PostBody.ps1
+++ b/source/private/New-PostBody.ps1
@@ -50,7 +50,7 @@ function New-PostBody {
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) begin"
         if ($PSCmdlet.MyInvocation.MyCommand.Name -ne 'New-EPRInstallation') {
-            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
+            Write-Warning "This function should only be used when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
         }
     }
     process {

--- a/source/private/Write-EPRInstallLog.ps1
+++ b/source/private/Write-EPRInstallLog.ps1
@@ -45,7 +45,7 @@ function Write-EPRInstallLog {
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) begin"
         if ($PSCmdlet.MyInvocation.MyCommand.Name -ne 'New-EPRInstallation') {
-            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
+            Write-Warning "This function should only be used when installing a new instance of ProcessRunner."
         }
     }
     process {

--- a/source/public/Convert-EasitGOExportString.ps1
+++ b/source/public/Convert-EasitGOExportString.ps1
@@ -8,20 +8,27 @@ function Convert-EasitGOExportString {
 
         By using *ConvertFrom-Json* the string is converted to a PSCustomObject.
 
-        If -Raw is used, the object is returned.
-        If -Raw is NOT used, *[New-FlatReturnObject](https://docs.easitgo.com/techspace/psmodules/eprglobalfunctions/functions/newflatreturnobject/)* is called to "flatten" the object.
+        If -Raw is used, the object is returned non "flattened".
+        If -Full is used, the whole export payload is returned, non "flattened".
+        If -Raw AND -Full is NOT used, *[New-FlatReturnObject](https://docs.easitgo.com/techspace/psmodules/eprglobalfunctions/functions/newflatreturnobject/)* is called to "flatten" the object.
     .EXAMPLE
         Convert-EasitGOExportString -InputString $Base64StringFromStdIn
     .EXAMPLE
         Convert-EasitGOExportString -InputString $Base64StringFromStdIn -Raw
     .EXAMPLE
+        Convert-EasitGOExportString -InputString $Base64StringFromStdIn -Full
+    .EXAMPLE
         Convert-EasitGOExportString -InputString $jsonString
     .EXAMPLE
         Convert-EasitGOExportString -InputString $jsonString -Raw
+    .EXAMPLE
+        Convert-EasitGOExportString -InputString $jsonString -Full
     .PARAMETER InputString
         String to convert to a PSCustomObject
     .PARAMETER Raw
         Specifies if the PSCustomObject should be "flatten" before returned
+    .PARAMETER Full
+        Specifies if the whole export body (including importhandler and generic properties) should be returned as a PSCustomObject. This parameter overrides -Raw
     .INPUTS
         None - You cannot pipe objects to this function
     .OUTPUTS
@@ -33,7 +40,9 @@ function Convert-EasitGOExportString {
         [Parameter(Mandatory)]
         [String]$InputString,
         [Parameter()]
-        [Switch]$Raw
+        [Switch]$Raw,
+        [Parameter()]
+        [Switch]$Full
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) begin"
@@ -58,6 +67,8 @@ function Convert-EasitGOExportString {
             throw $_
         }
         if ($Raw) {
+            return $rawEasitGOObject.itemToImport[0]
+        } elseif ($Full) {
             return $rawEasitGOObject
         } else {
             try {

--- a/source/public/New-FlatReturnObject.ps1
+++ b/source/public/New-FlatReturnObject.ps1
@@ -13,6 +13,7 @@ function New-FlatReturnObject {
         * DatabaseId
         * PropertyObjects
         * propertyName_rawValue (one for each property)
+        * Attachments
 
         If a property occurs more than one time, the property value will be an array of all values with that name.
     .EXAMPLE

--- a/tests/function/Convert-EasitGOExportString.Tests.ps1
+++ b/tests/function/Convert-EasitGOExportString.Tests.ps1
@@ -30,7 +30,7 @@ BeforeAll {
         }
     }
     $exportString = Get-Content -Path (Join-Path -Path $envSettings.TestDataDirectory -ChildPath 'exportExample.json') -Raw
-    $base64String = 'eyJpbXBvcnRoYW5kbGVyIjoibXlTY3JpcHQucHMxIiwiaXRlbVRvSW1wb3J0Ijp7InByb3BlcnR5IjpbeyJwcm9wZXJ0eTEiOiJzcGVjaWFsQ2hhcmFjdGVycyJ9XX19'
+    $base64String = Get-Content -Path (Join-Path -Path $envSettings.TestDataDirectory -ChildPath 'exportExampleBase64.txt') -Raw
 }
 Describe "Convert-EasitGOExportString" -Tag 'function','public' {
     It 'should have a parameter named InputString that accepts a string' {
@@ -38,6 +38,9 @@ Describe "Convert-EasitGOExportString" -Tag 'function','public' {
     }
     It 'should have a parameter named Raw that is a switch' {
         Get-Command "$($envSettings.CommandName)" | Should -HaveParameter Raw -Type [Switch]
+    }
+    It 'should have a parameter named Full that is a switch' {
+        Get-Command "$($envSettings.CommandName)" | Should -HaveParameter Full -Type [Switch]
     }
     It 'help section should have a SYNOPSIS' {
         ((Get-Help "$($envSettings.CommandName)" -Full).SYNOPSIS).Length | Should -BeGreaterThan 0
@@ -63,7 +66,55 @@ Describe "Convert-EasitGOExportString" -Tag 'function','public' {
     It 'should return a PSCustomObject (json)' {
         Convert-EasitGOExportString -InputString $exportString | Should -BeOfType [PSCustomObject]
     }
+    It '$returnedObject.ObjectId should be 23468 (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).ObjectId | Should -BeExactly 23468
+    }
+    It '$returnedObject.DatabaseId should be 18830:2 (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).DatabaseId | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.PropertyObjects.Count should be 0 (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).PropertyObjects.Count | Should -BeExactly 0
+    }
+    It '$returnedObject.Attachments.Count should be 0 (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).Attachments.Count | Should -BeExactly 0
+    }
+    It '$returnedObject.uid should be 23468 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).uid | Should -BeExactly 23468
+    }
+    It '$returnedObject.id should be 18830:2 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).id | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.property.Count should be 3 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).property.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.attachment.Count should be 1 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).attachment.Count | Should -BeExactly 1
+    }
     It 'should return a PSCustomObject (base64)' {
         Convert-EasitGOExportString -InputString $base64String | Should -BeOfType [PSCustomObject]
+    }
+    It '$returnedObject.ObjectId should be 23468 (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).ObjectId | Should -BeExactly 23468
+    }
+    It '$returnedObject.DatabaseId should be 18830:2 (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).DatabaseId | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.PropertyObjects.Count should be 0 (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).PropertyObjects.Count | Should -BeExactly 0
+    }
+    It '$returnedObject.Attachments.Count should be 0 (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).Attachments.Count | Should -BeExactly 0
+    }
+    It '$returnedObject.uid should be 23468 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).uid | Should -BeExactly 23468
+    }
+    It '$returnedObject.id should be 18830:2 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).id | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.property.Count should be 3 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).property.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.attachment.Count should be 1 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).attachment.Count | Should -BeExactly 1
     }
 }

--- a/tests/module/Convert-EasitGOExportString.Tests.ps1
+++ b/tests/module/Convert-EasitGOExportString.Tests.ps1
@@ -23,7 +23,55 @@ Describe "Convert-EasitGOExportString" -Tag 'module' {
     It 'should return a PSCustomObject (json)' {
         Convert-EasitGOExportString -InputString $exportString | Should -BeOfType [PSCustomObject]
     }
+    It '$returnedObject.PropertyObjects.Count should be 3 (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).PropertyObjects.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.assetCollection should be Arbetsstation bärbar avancerad (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).assetCollection | Should -BeExactly 'Arbetsstation bärbar avancerad'
+    }
+    It '$returnedObject.samAccountName should be klåra (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).samAccountName | Should -BeExactly 'klåra'
+    }
+    It '$returnedObject.dn should be CN=testsson\, test,OU=Users,DC=company,DC=com (json)' {
+        (Convert-EasitGOExportString -InputString $exportString).dn | Should -BeExactly 'CN=testsson\, test,OU=Users,DC=company,DC=com'
+    }
+    It '$returnedObject.uid should be 23468 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).uid | Should -BeExactly 23468
+    }
+    It '$returnedObject.id should be 18830:2 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).id | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.property.Count should be 3 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).property.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.attachment.Count should be 1 (json - raw)' {
+        (Convert-EasitGOExportString -InputString $exportString -Raw).attachment.Count | Should -BeExactly 1
+    }
     It 'should return a PSCustomObject (base64)' {
         Convert-EasitGOExportString -InputString $base64String | Should -BeOfType [PSCustomObject]
+    }
+    It '$returnedObject.PropertyObjects.Count should be 3 (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).PropertyObjects.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.assetCollection should be Arbetsstation bärbar avancerad (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).assetCollection | Should -BeExactly 'Arbetsstation bärbar avancerad'
+    }
+    It '$returnedObject.samAccountName should be klåra (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).samAccountName | Should -BeExactly 'klåra'
+    }
+    It '$returnedObject.dn should be CN=testsson\, test,OU=Users,DC=company,DC=com (base64)' {
+        (Convert-EasitGOExportString -InputString $base64String).dn | Should -BeExactly 'CN=testsson\, test,OU=Users,DC=company,DC=com'
+    }
+    It '$returnedObject.uid should be 23468 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).uid | Should -BeExactly 23468
+    }
+    It '$returnedObject.id should be 18830:2 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).id | Should -BeExactly '18830:2'
+    }
+    It '$returnedObject.property.Count should be 3 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).property.Count | Should -BeExactly 3
+    }
+    It '$returnedObject.attachment.Count should be 1 (base64 - raw)' {
+        (Convert-EasitGOExportString -InputString $base64String -Raw).attachment.Count | Should -BeExactly 1
     }
 }


### PR DESCRIPTION
This PR will fix issue #57 by adding a new parameter named Full.
If no parameter is used, a "flat" PSCustomObject from 'itemToImport[0]' is returned.
If -Raw is used, 'itemToImport[0]' is returned untouched.
If -Full is used, the whole export object is returned.