### PR TITLE
Warning about a parameter cannot be found when installing EPR

### DIFF
--- a/source/private/New-PostBody.ps1
+++ b/source/private/New-PostBody.ps1
@@ -49,11 +49,11 @@ function New-PostBody {
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) begin"
-        if ($PSCmdlet.MyInvocation.MyCommand.Name -ne 'New-EPRInstallation') {
-            Write-Warning "This function should only be used when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
-        }
     }
     process {
+        if ($((Get-PSCallStack)[1].Command) -ne 'New-EPRInstallation') {
+            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
+        }
         $items = @()
         $propertiesArray = @()
         foreach ($prop in $InstallerSettings.FeedbackSettings.postBody.properties) {

--- a/source/private/Write-EPRInstallLog.ps1
+++ b/source/private/Write-EPRInstallLog.ps1
@@ -44,11 +44,11 @@ function Write-EPRInstallLog {
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) begin"
-        if ($PSCmdlet.MyInvocation.MyCommand.Name -ne 'New-EPRInstallation') {
-            Write-Warning "This function should only be used when installing a new instance of ProcessRunner."
-        }
     }
     process {
+        if ($((Get-PSCallStack)[1].Command) -ne 'New-EPRInstallation') {
+            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
+        }
         $FormattedDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss.fff"
         $today = Get-Date -Format "yyyyMMdd"
         $LogName = "${LogName}_${today}.log"

--- a/source/private/Write-EPRInstallLog.ps1
+++ b/source/private/Write-EPRInstallLog.ps1
@@ -47,7 +47,7 @@ function Write-EPRInstallLog {
     }
     process {
         if ($((Get-PSCallStack)[1].Command) -ne 'New-EPRInstallation') {
-            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Easit.GO.Webservice' for posting data to Easit GO."
+            Write-Warning "This function should only be used (by 'New-EPRInstallation') when installing a new instance of ProcessRunner. Please use 'Write-CustomLog' instead."
         }
         $FormattedDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss.fff"
         $today = Get-Date -Format "yyyyMMdd"

--- a/source/public/New-EPRInstallation.ps1
+++ b/source/public/New-EPRInstallation.ps1
@@ -57,6 +57,10 @@ function New-EPRInstallation {
         [Switch]$DoNotSendInstallationDetailsToEasit
     )
     begin {
+        $Elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+		if ( -not $Elevated ) {
+		  throw "In order to install Easit Process Runner correctly, this session requires elevation (i.e open PowerShell as admin)."
+		}
         $InformationPreference = 'Continue'
         $script:ProgressPreference = 'SilentlyContinue'
         $startingDirectory = Get-Location
@@ -84,7 +88,6 @@ function New-EPRInstallation {
         if (Test-Path -Path $installPackagePath) {
             $script:loggingParameters = @{
                 LogDirectory = "$installPackagePath"
-                LogLevel = 'INFO'
             }
             Set-Location $installPackagePath
             Write-EPRInstallLog -Message "-- Installation start --" @loggingParameters


### PR DESCRIPTION
- update for how we check who called Write-EPRInstallLog
- add check if session is elevated and removed 'LogLevel' from loggingParameters hash as it is the same as default